### PR TITLE
Use any spreadsheet gem

### DIFF
--- a/heart_seed.gemspec
+++ b/heart_seed.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 3.0.0"
   spec.add_dependency "activerecord-import"
   spec.add_dependency "roo", ">= 1.13.2"
-  spec.add_dependency "spreadsheet", "0.9.7"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
spreadsheet v0.9.9 is broken, but fixed at spreadsheet 1.0.0

Revert "Can not open xls file when spreadsheet 0.9.9 and roo 1.13.2"

This reverts commit 4c93f64b1d51840341e9d806cd9ffdd081441dc7.
