### PR TITLE
Add :validate parameter

### DIFF
--- a/lib/heart_seed/db_seed.rb
+++ b/lib/heart_seed/db_seed.rb
@@ -119,11 +119,11 @@ module HeartSeed
     #                      other, using bulk insert. (`delete_all` and BULK INSERT)
     # @param shard_names [Array<String>]
     def self.import_all_with_shards(seed_dir: HeartSeed::Helper.seed_dir, tables: ENV["TABLES"], catalogs: ENV["CATALOGS"],
-                                    mode: ENV["MODE"] || BULK, shard_names: [])
+                                    mode: ENV["MODE"] || BULK, shard_names: [], validate: true)
       shard_names.each do |shard_name|
         ActiveRecord::Migration.say_with_time("import to shard: #{shard_name}") do
           ActiveRecord::Base.establish_connection(shard_name.to_sym)
-          import_all(seed_dir: seed_dir, tables: tables, catalogs: catalogs, mode: mode)
+          import_all(seed_dir: seed_dir, tables: tables, catalogs: catalogs, mode: mode, validate: validate)
         end
       end
     end

--- a/lib/heart_seed/db_seed.rb
+++ b/lib/heart_seed/db_seed.rb
@@ -8,7 +8,7 @@ module HeartSeed
     #
     # @param file_path [String]
     # @param model_class [Class] require. extends {ActiveRecord::Base}
-    def self.bulk_insert(file_path: nil, model_class: nil)
+    def self.bulk_insert(file_path: nil, model_class: nil, validate: true)
       fixtures = HeartSeed::Converter.read_fixture_yml(file_path)
       models = fixtures.each_with_object([]) do |fixture, response|
         response << model_class.new(fixture)
@@ -17,7 +17,7 @@ module HeartSeed
 
       model_class.transaction do
         model_class.delete_all
-        model_class.import(models)
+        model_class.import(models, validate: validate)
       end
     end
 
@@ -25,12 +25,12 @@ module HeartSeed
     #
     # @param file_path [String]
     # @param model_class [Class] require. extends {ActiveRecord::Base}
-    def self.insert(file_path: nil, model_class: nil)
+    def self.insert(file_path: nil, model_class: nil, validate: true)
       fixtures = HeartSeed::Converter.read_fixture_yml(file_path)
       model_class.transaction do
         model_class.delete_all
         fixtures.each do |fixture|
-          model_class.create!(fixture)
+          model_class.new(fixture).save!(validate: validate)
         end
       end
     end
@@ -39,15 +39,16 @@ module HeartSeed
     #
     # @param file_path [String]
     # @param model_class [Class] require. extends {ActiveRecord::Base}
-    def self.insert_or_update(file_path: nil, model_class: nil)
+    def self.insert_or_update(file_path: nil, model_class: nil, validate: true)
       fixtures = HeartSeed::Converter.read_fixture_yml(file_path)
       model_class.transaction do
         fixtures.each do |fixture|
           model = model_class.find_by(id: fixture["id"])
           if model
-            model.update!(fixture)
+            model.attributes = fixture
+            model.save!(validate: validate)
           else
-            model_class.create!(fixture)
+            model_class.new(fixture).save!(validate: validate)
           end
         end
       end
@@ -66,7 +67,7 @@ module HeartSeed
     #                      if `ACTIVE_RECORD`, import with ActiveRecord. (`delete_all` and `create!`)
     #                      if `UPDATE`, import with ActiveRecord. (if exists same record, `update!`)
     #                      other, using bulk insert. (`delete_all` and BULK INSERT)
-    def self.import_all(seed_dir: HeartSeed::Helper.seed_dir, tables: ENV["TABLES"], catalogs: ENV["CATALOGS"], mode: ENV["MODE"])
+    def self.import_all(seed_dir: HeartSeed::Helper.seed_dir, tables: ENV["TABLES"], catalogs: ENV["CATALOGS"], mode: ENV["MODE"], validate: true)
       mode ||= BULK
       target_table_names = parse_target_table_names(tables: tables, catalogs: catalogs)
 
@@ -80,7 +81,7 @@ module HeartSeed
           table_name = File.basename(file_path, '.*')
 
           ActiveRecord::Migration.say_with_time("#{file_path} -> #{table_name}") do
-            insert_seed(file_path: file_path, table_name: table_name, mode: mode)
+            insert_seed(file_path: file_path, table_name: table_name, mode: mode, validate: validate)
             ActiveRecord::Migration.say("[INFO] success", true)
           end
         end
@@ -96,7 +97,7 @@ module HeartSeed
           end
 
           ActiveRecord::Migration.say_with_time("#{file_path} -> #{table_name}") do
-            insert_seed(file_path: file_path, table_name: table_name, mode: mode)
+            insert_seed(file_path: file_path, table_name: table_name, mode: mode, validate: validate)
             ActiveRecord::Migration.say("[INFO] success", true)
           end
         end
@@ -159,16 +160,16 @@ module HeartSeed
     # @param file_path  [String] source seed yaml file
     # @param table_name [String] output destination table
     # @param mode       [String] #{BULK}, #{UPDARE} or #{ACTIVE_RECORD}
-    def self.insert_seed(file_path: nil, table_name: nil, mode: BULK)
+    def self.insert_seed(file_path: nil, table_name: nil, mode: BULK, validate: true)
       model_class = table_name.classify.constantize
       case mode
       when ACTIVE_RECORD
-        insert(file_path: file_path, model_class: model_class)
+        insert(file_path: file_path, model_class: model_class, validate: validate)
       when UPDATE
-        insert_or_update(file_path: file_path, model_class: model_class)
+        insert_or_update(file_path: file_path, model_class: model_class, validate: validate)
       else
         # default is BULK mode
-        bulk_insert(file_path: file_path, model_class: model_class)
+        bulk_insert(file_path: file_path, model_class: model_class, validate: validate)
       end
     end
     private_class_method :insert_seed

--- a/lib/heart_seed/db_seed.rb
+++ b/lib/heart_seed/db_seed.rb
@@ -8,6 +8,7 @@ module HeartSeed
     #
     # @param file_path [String]
     # @param model_class [Class] require. extends {ActiveRecord::Base}
+    # @param validate [Boolean] run ActiveRecord's validation. default: true
     def self.bulk_insert(file_path: nil, model_class: nil, validate: true)
       fixtures = HeartSeed::Converter.read_fixture_yml(file_path)
       models = fixtures.each_with_object([]) do |fixture, response|
@@ -25,6 +26,7 @@ module HeartSeed
     #
     # @param file_path [String]
     # @param model_class [Class] require. extends {ActiveRecord::Base}
+    # @param validate [Boolean] run ActiveRecord's validation. default: true
     def self.insert(file_path: nil, model_class: nil, validate: true)
       fixtures = HeartSeed::Converter.read_fixture_yml(file_path)
       model_class.transaction do
@@ -39,6 +41,7 @@ module HeartSeed
     #
     # @param file_path [String]
     # @param model_class [Class] require. extends {ActiveRecord::Base}
+    # @param validate [Boolean] run ActiveRecord's validation. default: true
     def self.insert_or_update(file_path: nil, model_class: nil, validate: true)
       fixtures = HeartSeed::Converter.read_fixture_yml(file_path)
       model_class.transaction do
@@ -67,6 +70,7 @@ module HeartSeed
     #                      if `ACTIVE_RECORD`, import with ActiveRecord. (`delete_all` and `create!`)
     #                      if `UPDATE`, import with ActiveRecord. (if exists same record, `update!`)
     #                      other, using bulk insert. (`delete_all` and BULK INSERT)
+    # @param validate    [Boolean] run ActiveRecord's validation. default: true
     def self.import_all(seed_dir: HeartSeed::Helper.seed_dir, tables: ENV["TABLES"], catalogs: ENV["CATALOGS"], mode: ENV["MODE"], validate: true)
       mode ||= BULK
       target_table_names = parse_target_table_names(tables: tables, catalogs: catalogs)
@@ -118,6 +122,7 @@ module HeartSeed
     #                      if `UPDATE`, import with ActiveRecord. (if exists same record, `update!`)
     #                      other, using bulk insert. (`delete_all` and BULK INSERT)
     # @param shard_names [Array<String>]
+    # @param validate    [Boolean] run ActiveRecord's validation. default: true
     def self.import_all_with_shards(seed_dir: HeartSeed::Helper.seed_dir, tables: ENV["TABLES"], catalogs: ENV["CATALOGS"],
                                     mode: ENV["MODE"] || BULK, shard_names: [], validate: true)
       shard_names.each do |shard_name|
@@ -160,6 +165,7 @@ module HeartSeed
     # @param file_path  [String] source seed yaml file
     # @param table_name [String] output destination table
     # @param mode       [String] #{BULK}, #{UPDARE} or #{ACTIVE_RECORD}
+    # @param validate   [Boolean] run ActiveRecord's validation. default: true
     def self.insert_seed(file_path: nil, table_name: nil, mode: BULK, validate: true)
       model_class = table_name.classify.constantize
       case mode

--- a/spec/heart_seed/db_seed_spec.rb
+++ b/spec/heart_seed/db_seed_spec.rb
@@ -50,6 +50,39 @@ describe HeartSeed::DbSeed do
     end
   end
 
+  context "When validate: false" do
+    subject { HeartSeed::DbSeed.send(method, file_path: file_path, model_class: model_class, validate: false) }
+
+    let(:file_path) { "#{FIXTURE_DIR}/invalid/invalid_comments.yml" }
+    let(:model_class) { Comment }
+
+    describe "#bulk_insert" do
+      let(:method) { :bulk_insert }
+      it{ expect{ subject }.to change(Comment, :count).by(2) }
+    end
+
+    describe "#insert" do
+      let(:method) { :insert }
+      it{ expect{ subject }.to change(Comment, :count).by(2) }
+    end
+
+    describe "#insert_or_update" do
+      let(:method) { :insert_or_update }
+
+      context "When insert" do
+        it{ expect{ subject }.to change(Comment, :count).by(2) }
+      end
+
+      context "When update" do
+        before { HeartSeed::DbSeed.insert(file_path: original_file_path, model_class: model_class) }
+
+        let(:original_file_path) { "#{FIXTURE_DIR}/comments.yml" }
+
+        it{ expect{ subject }.to change{ Comment.find(2).article_id }.from(1).to(0) }
+      end
+    end
+  end
+
   describe "#import_all" do
     subject{ HeartSeed::DbSeed.import_all(seed_dir: seed_dir, tables: tables, catalogs: catalogs, mode: mode) }
 


### PR DESCRIPTION
There are some occasions when I don't want any validation during seed import, especially when there are required associations.

I've added the `:validate` optional parameter which defaults to true, unchanging the previous behavior.